### PR TITLE
support non-string single column index

### DIFF
--- a/src/driver/dynamo/helpers/param-helper.ts
+++ b/src/driver/dynamo/helpers/param-helper.ts
@@ -22,7 +22,7 @@ const indexedWhere = (
             const value = options.where[column.propertyName]
             values.push(value)
         }
-        where[partitionKey] = values.join('#')
+        where[partitionKey] = values.length > 1 ? values.join('#') : values[0]
     }
     return isNotEmpty(where) ? where : options.where
 }


### PR DESCRIPTION
Indices can be for a single column. When that happens, the original column is used directly in the index and no new column is made for it. However, when using the index to search, the provided value is currently always converted to a string. That causes an error if the original column is not a string, as DynamoDB will refuse to match a string value to a non-string column.

The proposed change will keep the original value provided in the `where` clause if the index is for a single column.