### PR TITLE
Add FindOperators supported  by DynamoDB

### DIFF
--- a/src/driver/dynamo/helpers/DynamoAttributeHelper.ts
+++ b/src/driver/dynamo/helpers/DynamoAttributeHelper.ts
@@ -1,11 +1,9 @@
-import { BeginsWith } from '../models/FindOptions'
 import { poundToUnderscore } from './DynamoTextHelper'
 import { isNotEmpty } from './DynamoObjectHelper'
 
 export const dynamoAttributeHelper = {
     toAttributeNames (
         object: any,
-        beginsWith?: BeginsWith,
         attributeNames?: any
     ) {
         if (isNotEmpty(object)) {
@@ -15,10 +13,6 @@ export const dynamoAttributeHelper = {
                 const key = keys[i]
                 attributeNames[`#${poundToUnderscore(key)}`] = key
             }
-        }
-        if (beginsWith) {
-            attributeNames[`#${poundToUnderscore(beginsWith.attribute)}`] =
-                beginsWith.attribute
         }
         return attributeNames
     }

--- a/src/driver/dynamo/models/FindOptions.ts
+++ b/src/driver/dynamo/models/FindOptions.ts
@@ -2,25 +2,37 @@ import { dynamoAttributeHelper } from '../helpers/DynamoAttributeHelper'
 import { poundToUnderscore } from '../helpers/DynamoTextHelper'
 import { isNotEmpty } from '../helpers/DynamoObjectHelper'
 import { marshall } from '@aws-sdk/util-dynamodb'
+import { FindOperator } from 'typeorm'
 
-export class BeginsWith {
-    attribute: string
-    value: string
+export const BeginsWith = (value: string) =>
+    new FindOperator('beginsWith' as any, value)
+
+const operators: Record<
+    string,
+    (property: string, value: string, operator: any) => string
+> = {
+    and: (property, value, operator) =>
+        operator.value.map((operator: any, i: number) =>
+            operators[operator.type](property, `${value}${i}`, operator)
+        ).join(' and '),
+    lessThan: (property, value) => `${property} < ${value}`,
+    lessThanOrEqual: (property, value) => `${property} <= ${value}`,
+    moreThan: (property, value) => `${property} > ${value}`,
+    moreThanOrEqual: (property, value) => `${property} >= ${value}`,
+    equal: (property, value) => `${property} = ${value}`,
+    between: (property, value) => `${property} BETWEEN ${value[0]} AND ${value[1]}`,
+    beginsWith: (property, value) => `begins_with(${property}, ${value})`
 }
 
 export class FindOptions {
     index?: string
     where?: any
-    beginsWith?: BeginsWith
     limit?: number
     sort?: string
     exclusiveStartKey?: string
 
     static toAttributeNames (findOptions: FindOptions) {
-        return dynamoAttributeHelper.toAttributeNames(
-            findOptions.where,
-            findOptions.beginsWith
-        )
+        return dynamoAttributeHelper.toAttributeNames(findOptions.where)
     }
 
     static toKeyConditionExpression (findOptions: FindOptions) {
@@ -30,22 +42,27 @@ export class FindOptions {
             for (let i = 0; i < keys.length; i++) {
                 const key = keys[i]
                 const attribute = poundToUnderscore(key)
-                values.push(`#${attribute} = :${attribute}`)
+                if (findOptions.where[key] instanceof FindOperator) {
+                    if (operators[findOptions.where[key].type]) {
+                        values.push(
+                            operators[findOptions.where[key].type](
+                                `#${attribute}`,
+                                `:${attribute}`,
+                                findOptions.where[key]
+                            )
+                        )
+                    } else {
+                        throw new Error(
+                            `Operator "${findOptions.where[key].type}" not supported`
+                        )
+                    }
+                } else {
+                    values.push(`#${attribute} = :${attribute}`)
+                }
             }
-            return FindOptions.appendBeginsWith(
-                values.join(' and '),
-                findOptions.beginsWith
-            )
+            return values.join(' and ')
         }
         return undefined
-    }
-
-    static appendBeginsWith (expression: string, beginsWith?: BeginsWith) {
-        if (beginsWith) {
-            const attribute = poundToUnderscore(beginsWith.attribute)
-            return `${expression} and begins_with(#${attribute}, :${attribute})`
-        }
-        return expression
     }
 
     static toExpressionAttributeValues (findOptions: FindOptions) {
@@ -54,12 +71,22 @@ export class FindOptions {
             const values: any = {}
             for (let i = 0; i < keys.length; i++) {
                 const key = keys[i]
-                values[`:${poundToUnderscore(key)}`] = marshall(findOptions.where[key])
-            }
-            if (findOptions.beginsWith) {
-                values[
-                    `:${poundToUnderscore(findOptions.beginsWith.attribute)}`
-                ] = marshall(findOptions.beginsWith.value)
+                if (findOptions.where[key] instanceof FindOperator) {
+                    if (findOptions.where[key].type === 'and') {
+                        findOptions.where[key].value.forEach(
+                            (operator: any, i: number) => {
+                                values[`:${poundToUnderscore(key)}${i}`] =
+                                    marshall(operator.value)
+                            }
+                        )
+                    } else {
+                        values[`:${poundToUnderscore(key)}`] =
+                            marshall(findOptions.where[key].value)
+                    }
+                } else {
+                    values[`:${poundToUnderscore(key)}`] =
+                        marshall(findOptions.where[key])
+                }
             }
             return values
         }

--- a/test/helpers/param-helper.test.ts
+++ b/test/helpers/param-helper.test.ts
@@ -1,5 +1,5 @@
 import expect from 'expect'
-import { FindOptions, UpdateExpressionOptions, paramHelper } from '../../src'
+import { BeginsWith, FindOptions, UpdateExpressionOptions, paramHelper } from '../../src'
 
 const MACHINE_ID = '9117e83c-6e58-424b-9650-6027c8b67386'
 const MONTH_ID = `${MACHINE_ID}-2020-12`
@@ -38,11 +38,8 @@ describe('param-helper', () => {
         const options = new FindOptions()
         options.index = 'searchByNameIndex'
         options.where = {
-            searchInitial: 'm'
-        }
-        options.beginsWith = {
-            attribute: 'searchName',
-            value: 'my-machine'
+            searchInitial: 'm',
+            searchName: BeginsWith('my-machine')
         }
 
         /** when: **/


### PR DESCRIPTION
DynamoDB supports multiple operators in `KeyConditionExpressions`: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.KeyConditionExpressions.html

This PR adds support for the corresponding `FindOperator`s from TypeORM, and turns the `BeginsWith` class into a `FindOperator` so it's handled the same way as the others.

For now I just updated the test for `BeginsWith`, but I can also add tests for the other operators. Just let me know!