### PR TITLE
fix batchRead response, no need to unmarshall

### DIFF
--- a/src/driver/dynamo/entity-manager/DynamoEntityManager.ts
+++ b/src/driver/dynamo/entity-manager/DynamoEntityManager.ts
@@ -378,7 +378,7 @@ export class DynamoEntityManager extends EntityManager {
                     RequestItems: requestItems
                 })
             if (response.Responses !== undefined) {
-                items = items.concat(unmarshallAll(response.Responses[metadata.tablePath]))
+                items = items.concat(response.Responses[metadata.tablePath])
             }
         }
         return items


### PR DESCRIPTION
The previous code was throwing errors because the values were not "unmarshallable"