### PR TITLE
remove non-existant promise property access on waitUntilActive

### DIFF
--- a/src/driver/dynamo/helpers/DynamoGlobalSecondaryIndexHelper.ts
+++ b/src/driver/dynamo/helpers/DynamoGlobalSecondaryIndexHelper.ts
@@ -175,7 +175,6 @@ export const waitUntilActive = async (db: any, tableName: string) => {
                 .describeTable({
                     TableName: tableName
                 })
-                .promise()
             const status = result.Table.TableStatus
             if (status === 'ACTIVE') {
                 break


### PR DESCRIPTION
The current code throws many errors when there are changes to table indices because it tries to call `.promise()` on the return of `describeTable` inside `waitUntilActive`, but that property doesn't seem to exist as the return is already a promise