### PR TITLE
handle sort keys when sanitizing where conditions in indexedWhere

### DIFF
--- a/src/driver/dynamo/helpers/param-helper.ts
+++ b/src/driver/dynamo/helpers/param-helper.ts
@@ -23,6 +23,16 @@ const indexedWhere = (
             values.push(value)
         }
         where[partitionKey] = values.length > 1 ? values.join('#') : values[0]
+        if (index.where) {
+            const sortColumns = index.where.split('#')
+            const sortValues = []
+            for (let i = 0; i < sortColumns.length; i += 1) {
+                sortValues.push(options.where[sortColumns[i]])
+            }
+            if (sortValues.length) {
+                where[index.where] = sortValues.length > 1 ? sortValues.join('#') : sortValues[0]
+            }
+        }
     }
     return isNotEmpty(where) ? where : options.where
 }


### PR DESCRIPTION
I don't know how we didn't notice this before, but sort keys were never being used in queries, as the sort key `where` conditions were getting deleted by `indexedWhere`.

This wasn't caught by tests because they don't pass the `indices` array into the function, and `indexedWhere` does nothing if it doesn't find the index (and consequently doesn't sanitize the `where` conditions, avoiding the issue)