### PR TITLE
mock indices in 'find beginsWith' test to cover indexedWhere

### DIFF
--- a/test/helpers/param-helper.test.ts
+++ b/test/helpers/param-helper.test.ts
@@ -1,5 +1,6 @@
 import expect from 'expect'
 import { BeginsWith, FindOptions, UpdateExpressionOptions, paramHelper } from '../../src'
+import { IndexMetadata } from 'typeorm/metadata/IndexMetadata.js'
 
 const MACHINE_ID = '9117e83c-6e58-424b-9650-6027c8b67386'
 const MONTH_ID = `${MACHINE_ID}-2020-12`
@@ -41,9 +42,16 @@ describe('param-helper', () => {
             searchInitial: 'm',
             searchName: BeginsWith('my-machine')
         }
+        const indices = [{
+            name: 'searchByNameIndex',
+            columns: [{
+                propertyName: 'searchInitial'
+            }],
+            where: 'searchName'
+        } as IndexMetadata]
 
         /** when: **/
-        const params = paramHelper.find('local-toucan-scores', options)
+        const params = paramHelper.find('local-toucan-scores', options, indices)
 
         /** then: **/
         expect(params).toEqual({


### PR DESCRIPTION
This makes the test fail without the fix that was merged in this PR: https://github.com/blueleader07/typeorm-dynamodb/pull/9