### PR TITLE
Expose executeStatement on repository to execute PartiQL queries

### DIFF
--- a/src/driver/dynamo/DynamoClient.ts
+++ b/src/driver/dynamo/DynamoClient.ts
@@ -27,7 +27,9 @@ import {
     BatchWriteCommand,
     DeleteCommand,
     DynamoDBDocumentClient,
-    PutCommand, UpdateCommand
+    PutCommand, UpdateCommand,
+    ExecuteStatementCommandInput,
+    ExecuteStatementCommand
 } from '@aws-sdk/lib-dynamodb'
 
 let dynamoDBDocumentClient: DynamoDBDocumentClient
@@ -101,6 +103,13 @@ export class DynamoClient {
             console.log('dynamodb batchWrite', params)
         }
         return this.getClient().send(new BatchWriteCommand(params))
+    }
+
+    executeStatement (params: ExecuteStatementCommandInput) {
+        if (environmentUtils.isTrue('DEBUG_DYNAMODB')) {
+            console.log('dynamodb executeStatement', params)
+        }
+        return this.getClient().send(new ExecuteStatementCommand(params))
     }
 
     deleteTable (params: DeleteTableInput) {

--- a/src/driver/dynamo/entity-manager/DynamoEntityManager.ts
+++ b/src/driver/dynamo/entity-manager/DynamoEntityManager.ts
@@ -416,12 +416,14 @@ export class DynamoEntityManager extends EntityManager {
      */
     async executeStatement (
         statement: string,
-        params?: any[]
+        params?: any[],
+        nextToken?: string
     ) {
         const dbClient = getDocumentClient()
         return dbClient.executeStatement({
             Statement: statement,
-            Parameters: params
+            Parameters: params,
+            NextToken: nextToken
         })
     }
 }

--- a/src/driver/dynamo/entity-manager/DynamoEntityManager.ts
+++ b/src/driver/dynamo/entity-manager/DynamoEntityManager.ts
@@ -411,4 +411,18 @@ export class DynamoEntityManager extends EntityManager {
                 })
         }
     }
+
+    /**
+     * Execute a statement on DynamoDB.
+     */
+    async executeStatement (
+        statement: string,
+        params?: any[]
+    ) {
+        const dbClient = getDocumentClient()
+        return dbClient.executeStatement({
+            Statement: statement,
+            Parameters: params
+        })
+    }
 }

--- a/src/driver/dynamo/entity-manager/DynamoEntityManager.ts
+++ b/src/driver/dynamo/entity-manager/DynamoEntityManager.ts
@@ -10,7 +10,6 @@ import { ObjectId } from 'typeorm/driver/mongodb/typings'
 import { ObjectLiteral } from 'typeorm/common/ObjectLiteral'
 import { FindOptionsUtils } from 'typeorm/find-options/FindOptionsUtils'
 import { FindOneOptions } from 'typeorm/find-options/FindOneOptions'
-import { DeepPartial } from 'typeorm/common/DeepPartial'
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity'
 import { DeleteResult } from 'typeorm/query-builder/result/DeleteResult'
 import { DynamoQueryRunner } from '../DynamoQueryRunner'
@@ -235,7 +234,7 @@ export class DynamoEntityManager extends EntityManager {
      */
     async put<Entity> (
         target: EntityTarget<Entity>,
-        entity: DeepPartial<Entity> | DeepPartial<Entity>[]
+        entity: ObjectLiteral | ObjectLiteral[]
     ): Promise<any | any[]> {
         if (Array.isArray(entity)) {
             return this.putMany(target, entity)

--- a/src/driver/dynamo/repository/DynamoRepository.ts
+++ b/src/driver/dynamo/repository/DynamoRepository.ts
@@ -172,8 +172,17 @@ export class DynamoRepository<
     }
 
     async executeStatement (statement: string, params?: any[]) {
-        const result = await this.manager.executeStatement(statement, params)
-        return result.Items as Entity[] | undefined
+        let result = await this.manager.executeStatement(statement, params)
+        const results = result.Items as Entity[] | undefined
+        while (result.NextToken) {
+            result = await this.manager.executeStatement(
+                statement,
+                params,
+                result.NextToken
+            )
+            results!.push(...(result.Items as Entity[]))
+        }
+        return results
     }
 
     /**

--- a/src/driver/dynamo/repository/DynamoRepository.ts
+++ b/src/driver/dynamo/repository/DynamoRepository.ts
@@ -171,6 +171,11 @@ export class DynamoRepository<
         return this.manager.batchWrite(this.metadata.tableName, writes)
     }
 
+    async executeStatement (statement: string, params?: any[]) {
+        const result = await this.manager.executeStatement(statement, params)
+        return result.Items as Entity[] | undefined
+    }
+
     /**
      * @deprecated use put(...) or updateExpression(...) for dynamodb.
      */

--- a/test/repositories/dynamic-repository.test.ts
+++ b/test/repositories/dynamic-repository.test.ts
@@ -74,6 +74,41 @@ describe('dynamic-repository', () => {
         expect(items).toBeDefined()
     })
 
+    it('executeStatement', async (): Promise<any> => {
+        await open({
+            entities: [Dummy],
+            synchronize: true
+        })
+        const repository = getRepository(Dummy)
+
+        const dummy: any = new Dummy()
+        dummy.id = '123'
+        dummy.name = 'some-dummy-name'
+        dummy.adjustmentGroupId = '1'
+        dummy.adjustmentStatus = 'processed'
+        dummy.error = undefined
+
+        const results: any = {
+            Items: [dummy]
+        }
+
+        const executeStatementStub = sinon.stub(DynamoClient.prototype, 'executeStatement')
+        executeStatementStub.resolves(results)
+        const putStub = sinon.stub(DynamoClient.prototype, 'put')
+        putStub.resolves()
+
+        await repository.put(dummy)
+
+        const items = await repository.executeStatement(
+            'SELECT * FROM dummy_t WHERE "id#adjustmentStatus" IN [?]',
+            ['123#processed']
+        )
+
+        expect(putStub.calledOnce).toBe(true)
+        expect(executeStatementStub.calledOnce).toBe(true)
+        expect(items).toBeDefined()
+    })
+
     it('query', async (): Promise<any> => {
         await open({
             entities: [Dummy],


### PR DESCRIPTION
I needed to do `batchGet` on a secondary index, and using a PartiQL statement seems to be the only way without sending many get requests to DynamoDB or scanning the table.

This PR exposes the `executeStatement` function from `lib-dynamodb` on the repository, aliasing the return type with the entity.

It also includes a tiny commit fixing a small type error.