### PR TITLE
Allow customizing client config

### DIFF
--- a/src/driver/dynamo/DynamoClient.ts
+++ b/src/driver/dynamo/DynamoClient.ts
@@ -18,7 +18,8 @@ import {
     CreateTableInput,
     UpdateTableInput,
     UpdateTableCommand,
-    ListTablesInput
+    ListTablesInput,
+    DynamoDBClientConfigType
 } from '@aws-sdk/client-dynamodb'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { environmentUtils } from './utils/environment-utils'
@@ -36,7 +37,7 @@ import { getRegion } from './helpers/region-helper'
 let dynamoDBDocumentClient: DynamoDBDocumentClient
 
 export class DynamoClient {
-    getClient (): DynamoDBDocumentClient {
+    getClient (config: DynamoDBClientConfigType = {}): DynamoDBDocumentClient {
         if (!dynamoDBDocumentClient) {
             const ClientDynamoDb = PlatformTools.load('@aws-sdk/client-dynamodb')
             const LibDynamoDb = PlatformTools.load('@aws-sdk/lib-dynamodb')
@@ -45,7 +46,8 @@ export class DynamoClient {
                 endpoint: environmentUtils.getVariable('DYNAMO_ENDPOINT'),
                 requestHandler: new NodeHttpHandler({
                     requestTimeout: 10000 // <- this decreases the emfiles count, the Node.js default is 120000
-                })
+                }),
+                ...config
             })
             dynamoDBDocumentClient = LibDynamoDb.DynamoDBDocumentClient.from(client, {
                 marshallOptions: {

--- a/src/driver/dynamo/managers/datasource-manager.ts
+++ b/src/driver/dynamo/managers/datasource-manager.ts
@@ -31,6 +31,8 @@ import { AuroraMysqlDriver } from 'typeorm/driver/aurora-mysql/AuroraMysqlDriver
 import { AuroraPostgresDriver } from 'typeorm/driver/aurora-postgres/AuroraPostgresDriver'
 import { CapacitorDriver } from 'typeorm/driver/capacitor/CapacitorDriver'
 import { SpannerDriver } from 'typeorm/driver/spanner/SpannerDriver'
+import { DynamoDBClientConfigType } from '@aws-sdk/client-dynamodb'
+import { DynamoClient } from '../DynamoClient'
 
 let connection: any = null
 let entityManager: any = null
@@ -210,6 +212,7 @@ PlatformTools.load = function (name) {
 
 export class DatasourceManagerOptions {
     entities?: ((Function | string | EntitySchema))[];
+    clientConfig?: DynamoDBClientConfigType;
     synchronize?: boolean
 }
 
@@ -227,6 +230,10 @@ export const datasourceManager = {
                 entities: options?.entities
             }
             connection = await new DataSource(connectionOptions).initialize()
+        }
+
+        if (options.clientConfig) {
+            new DynamoClient().getClient(options.clientConfig)
         }
 
         if (options.synchronize) {


### PR DESCRIPTION
This PR allows users to specify the configuration for the DynamoDB client, making it possible to overwrite the default options.

I have successfully used this to connect to an instance of local DynamoDB running on localhost with this config:

```typescript
import { NodeHttpHandler } from "@smithy/node-http-handler";
import { Agent } from "http";

// code where the connection is opened:
datasourceManager.open({
  entities,
  clientConfig: {
    endpoint: "http://localhost:8000",
    region: "local",
    credentials: {
      accessKeyId: "dummy",
      secretAccessKey: "dummy",
    },
    // local DynamoDB is slow sometimes, so this increases the connection timeout
    requestHandler: new NodeHttpHandler({
      httpAgent: new Agent({
        keepAlive: true,
      }),
      connectionTimeout: 300000,
      socketTimeout: 300000,
    }),
  },
})
```